### PR TITLE
Add Twitter Card info

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,15 @@
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+  
+  {% if page.title == "home" %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="https://2019.restfest.org/images/logo.png">
+    <meta name="twitter:image:alt" content="REST Fest Logo">
+    <meta name="og:url" content="https://2019.restfest.org/east/">
+    <meta name="og:title" content="REST Fest East">
+    <meta name="og:description" content="Our objective is to give people interested in REST, Hypermedia APIs, crafting web service APIs, or any related topics a chance to get together in an informal setting to share ideas, trade stories, and show examples of current work.">
+  {% endif %}
 
   <!-- Site Properties -->
   <title>REST Fest - RESTful Web Services Unconference in {{ site.data[page.layout].title }} - {{ page.title }}</title>


### PR DESCRIPTION
**Note: I have not tested this. Someone might want to do some testing if this PR is something you desire. I'm happy to help, but I can't test until another day.**

This adds Twitter Card info in order to show cards on Twitter posts. It uses a large image summary. More information can be found in the card documentation.

https://cards-dev.twitter.com/validator
